### PR TITLE
Tweaks to table tennis example

### DIFF
--- a/docs/src/tutorial/tabletennis.md
+++ b/docs/src/tutorial/tabletennis.md
@@ -11,7 +11,7 @@ Now we implement a small toy example for concurrency with three actors using onl
 We simulate table-tennis where a player has a name and a capability. If he gets a ball with a difficulty exceeding his capability, he looses it. Players log to a print server actor.
 
 ```julia
-using Actors, Printf, Random
+using Actors, Printf, Random, .Threads
 import Actors: spawn
 
 struct Player{S,T}
@@ -60,7 +60,7 @@ prn = spawn(s->print(@sprintf("%s\n", s)))
 ping = spawn(Player("Ping", 0.8), prn, thrd=3)
 pong = spawn(Player("Pong", 0.75), prn, thrd=4)
 
-send(ping, Serve(pong))
+send(ping, Serve(pong));
 ```
 
 To execute the program we include the file:

--- a/examples/pingpong.jl
+++ b/examples/pingpong.jl
@@ -42,4 +42,4 @@ prn = spawn(s->print(@sprintf("%s\n", s))) # a print server
 ping = spawn(Player("Ping", 0.8), prn, thrd=3)
 pong = spawn(Player("Pong", 0.75), prn, thrd=4)
 
-send(ping, Serve(pong))
+send(ping, Serve(pong));


### PR DESCRIPTION
If you copy-paste the table tennis example from the documentation you get messy output due to interleaved printing of the type and print actor:
```julia
julia> send(ping, Serve(pong))
(Serve{Link{Channel{Any}}}(LinkPing serves
{Pong serves Ping
ChannelPing serves Pong
{Pong serves Ping
AnyPing serves Pong
}Pong looses ball from Ping
}(Channel{Any}(32), 1, :default)),)
```